### PR TITLE
Updating libraries to compile with IDE 1.8.5

### DIFF
--- a/Cube.cpp
+++ b/Cube.cpp
@@ -180,7 +180,7 @@ void loadColorPlaneZ(
   }
 
                            // Disable 7154, MY9262 latch complete
-  PORTE |=  (1 << 6);      // digitalWrite(PIN_LED_EN, HIGH);
+//  PORTE |=  (1 << 6);      // digitalWrite(PIN_LED_EN, HIGH);          // mjh
   PORTD &= ~(1 << 6);      // digitalWrite(PIN_LED_LAT, LOW);
 
   byte colorPlaneZSelect = color + (planeZ * 3);
@@ -189,7 +189,7 @@ void loadColorPlaneZ(
   PORTB |= (colorPlaneZSelect << 4);
 
 // Enable 74154
-  PORTE &= ~(1 << 6);      // digitalWrite(PIN_LED_EN, LOW);
+//  PORTE &= ~(1 << 6);      // digitalWrite(PIN_LED_EN, LOW);
 
   // Re-enable SPI hardware if it was enabled
   if(spe_set)

--- a/color.h
+++ b/color.h
@@ -9,7 +9,7 @@
 #define COLOR_h
 
 typedef struct {
-  byte color[3];
+  int color[3];
 }
   rgb_t;
 

--- a/parser.h
+++ b/parser.h
@@ -42,7 +42,7 @@ command_t commands[] = {
   "set",       parseCommandSet,       executeNop,
   "next",      parseCommandNext,      executeNop,
   "line",      parseCommandLine,      executeNop,
-  "box",       parseCommandBox,      executeNop,
+  "box",       parseCommandBox,       executeNop,
   "sphere",    parseCommandSphere,    executeNop,
   "setplane",  parseCommandSetplane,  executeNop,
   "copyplane", parseCommandCopyplane, executeNop,

--- a/parser.h
+++ b/parser.h
@@ -15,7 +15,7 @@ static const byte RBRAC = 0x29;  // Right bracket ')'
 typedef struct command_s {
   char  *name;
   byte (*parser) (
-         char             *message,
+         const char             *message,
          byte              length,
          byte             *position,
          struct command_s *command,

--- a/readmeMJH.md
+++ b/readmeMJH.md
@@ -1,0 +1,18 @@
+steps to be taken to allow this example to work :
+this file will be updated as I progress and recover the data from experience.
+
+1. Download and install the Arduino IDE { we are now at version 1.8.5 }
+
+2. when attempting to build errors will occur due to missing file Cube.h . To fix this we need the library
+
+2.1 Download the ZIP from the freetronics github repo site (even on Linux) and unzip into "libraries" in the tree where the IDE was installed. 
+
+3. restart the IDE - fine but the compiler enforces stricter rules now than when the example was created.
+
+4. Note : I already had a fork of the repo in ECA.
+
+5. So I removed the "unzipped" file from the repo as it has no version control and used the repo from the ECA user in github. I changed the files to make the compilation work and will now investigate further to merge them, when acceptable, into the mastaer...
+
+6. There are still several warnings at compile time with the Cube code. I will attempt to fix them.
+
+

--- a/readmeMJH.md
+++ b/readmeMJH.md
@@ -15,4 +15,6 @@ this file will be updated as I progress and recover the data from experience.
 
 6. There are still several warnings at compile time with the Cube code. I will attempt to fix them.
 
+7. be aware that if you repeat the compilation then with some environment settings the warnings will 'go away' and it will appear clean...
+
 

--- a/serial.cpp
+++ b/serial.cpp
@@ -35,10 +35,11 @@ void Cube::serialBegin(
       serial = & Serial;
       break;
 
-    case 1:
+/*    case 1:
       Serial1.begin(baudRate);
       serial = & Serial1;
       break;
+      */    // mjh
   }
 
   if (serial) {


### PR DESCRIPTION
With renewed interest in the cube4 I rebuilt some code and it seems the compiler enforces stricter rules than before. I have thus started to fix these issues. The solutions may not be perfect and certainly are not the only methods that could work depending on other limitations/requirements. 
This is also to show that cube4 is still stimulating at least a small group of enthusiasts.